### PR TITLE
Don't use std::pair<T*,size_t> when T(&)[N] works fine.

### DIFF
--- a/rM/include/ParseTable.hpp
+++ b/rM/include/ParseTable.hpp
@@ -110,14 +110,14 @@ namespace fc::rM
 namespace fc::rM::tablemap
 {
   template <typename T>
-  constexpr std::pair<TableEntry<i32 T::*> *, size_t> M;
+  char M = throw;  // you should never use this primary template
 
   template <>
-  constexpr inline auto M<Page> = std::make_pair(PageTable, std::extent_v<decltype(PageTable)>);
+  constexpr inline auto& M<Page> = PageTable;
   template <>
-  constexpr inline auto M<Layer> = std::make_pair(LayerTable, std::extent_v<decltype(LayerTable)>);
+  constexpr inline auto& M<Layer> = LayerTable;
   template <>
-  constexpr inline auto M<Line> = std::make_pair(LineTable, std::extent_v<decltype(LineTable)>);
+  constexpr inline auto& M<Line> = LineTable;
   template <>
-  constexpr inline auto M<Point> = std::make_pair(PointTable, std::extent_v<decltype(PointTable)>);
+  constexpr inline auto& M<Point> = PointTable;
 } // namespace fc::rM::tablemap

--- a/rM/include/Parser.hpp
+++ b/rM/include/Parser.hpp
@@ -16,12 +16,10 @@ namespace fc::rM
     T miniParser()
     {
       T Record;
-      auto [M, Sz] = tablemap::M<T>;
-      for (size_t i = 0; i < Sz; ++i)
-      {
+      for (auto&& elt : tablemap::M<T>) {
         i64 S = 0;
         Stream.read(reinterpret_cast<char *>(&S), sizeof(S));
-        M[i].assertOrAssign(Record, S);
+        elt.assertOrAssign(Record, S);
       }
       return Record;
     };


### PR DESCRIPTION
Inspired by the recent std-proposals thread. I think this is what you really want here.
(And then of course I'd look at eliminating the redundant variables `LineTable`, `PageTable`, etc. and just defining `M<Line>`, `M<Page>`, etc. as array variables directly.)